### PR TITLE
Support use in other repositories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,16 @@ inputs:
     description: 'URL for Discord webhook'
     required: true
 
+  repository:
+    description: |
+      The repository whose disruptive tests you want to fetch.
+
+      Must be specified as "<owner-name>/<repository-name>" (example:
+      "facebook/react").
+
+      Defaults to the repository that is running the workflow.
+    required: false
+
 runs:
   using: 'node12'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'BuildPulse-Discord'
-description: 'Gather top 5 disruptive tests from BuildPulse and post them to a Discord channel'
+description: 'Gather top 3 disruptive tests from BuildPulse and post them to a Discord channel'
 branding:
   icon: 'activity'
   color: 'yellow'

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const core = require('@actions/core');
 
 try {
   (async () => {
-    const repo = process.env.GITHUB_REPOSITORY;
+    const repo = core.getInput('repository') || process.env.GITHUB_REPOSITORY;
     const bpData = (await axios(
       {
         url: `https://buildpulse.io/api/repos/${repo}/tests`,

--- a/index.js
+++ b/index.js
@@ -3,9 +3,10 @@ const core = require('@actions/core');
 
 try {
   (async () => {
+    const repo = process.env.GITHUB_REPOSITORY;
     const bpData = (await axios(
       {
-        url: 'https://buildpulse.io/api/repos/rabatta-aps/rabatta/tests',
+        url: `https://buildpulse.io/api/repos/${repo}/tests`,
         headers: {
           Authorization: `token ${core.getInput('buildPulse-api-token')}`
         }


### PR DESCRIPTION
👋 @Benjadahl: Thanks so much for putting this action together! ✨ 

This pull request proposes replacing the URL for the `rabatta-aps/rabatta` repository with a dynamic URL so that this action can be used for any GitHub repository.

By default, it fetches the repository name from the [`GITHUB_REPOSITORY` environment variable](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables). So, for example, if you're running this action inside a workflow in the `rabatta-aps/rabatta` repository, no additional configuration is needed. It will correctly use `rabatta-aps/rabatta` in the URL.

Optionally, it allows you to specify a `repository` input field. This is useful if your action workflow is running in a different repository (e.g., `rabatta-aps/automation`) and you want to fetch BuildPulse data for another repository (e.g., `rabatta-aps/rabatta`).